### PR TITLE
Make deployment work again

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,6 +35,13 @@ jobs:
         with:
           toolchain: stable
 
+      - name: "Install prerequisites"
+        run: |
+          dpkq-query -l libasound2-dev || true
+          sudo apt-get update
+          sudo apt install libdbus-1-dev alsa libasound2-dev
+          dpkq-query -l libasound2-dev || true
+
       - name: "Rust: Tests"
         run: |
           cargo test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,19 @@ jobs:
           args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
           sccache: 'true'
           manylinux: auto
+          before-script-linux: |
+            case "${{ matrix.target }}" in
+              "aarch64" | "armv7" | "s390x" | "ppc64le")
+                # NOTE: pypa/manylinux docker images are Debian based
+                sudo apt-get update
+                sudo apt-get install -y libasound2-dev libdbus-1-dev
+                ;;
+              "x86" | "x86_64")
+                # NOTE: rust-cross/manylinux docker images are CentOS based
+                yum update -y
+                yum install -y libasound2-dev libdbus-1-dev
+                ;;
+            esac
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -79,6 +92,19 @@ jobs:
           args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
           sccache: 'true'
           manylinux: musllinux_1_2
+          before-script-linux: |
+            case "${{ matrix.target }}" in
+              "aarch64" | "armv7" | "s390x" | "ppc64le")
+                # NOTE: pypa/manylinux docker images are Debian based
+                sudo apt-get update
+                sudo apt-get install -y libasound2-dev libdbus-1-dev
+                ;;
+              "x86" | "x86_64")
+                # NOTE: rust-cross/manylinux docker images are CentOS based
+                yum update -y
+                yum install -y libasound2-dev libdbus-1-dev
+                ;;
+            esac
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,8 @@ jobs:
             target: x86
           # - runner: ubuntu-latest
           #   target: aarch64
-          # - runner: ubuntu-latest
-          #   target: armv7
+          - runner: ubuntu-latest
+            target: armv7
           # - runner: ubuntu-latest
           #   target: s390x
           # - runner: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
+          args: --release --out dist --interpreter python3.10 python3.11 python3.12
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -53,10 +53,14 @@ jobs:
             uname -a
             cat /etc/*-release
             case "${{ matrix.platform.target }}" in
-              "aarch64" | "armv7" | "s390x" | "ppc64le")
+              "aarch64" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based
                 sudo apt-get update
                 sudo apt-get install -y libasound2-dev
+                ;;
+              "armv7")
+                sudo apt-get update
+                sudo apt-get install -y libasound2-dev:armhf
                 ;;
               "x86" | "x86_64")
                 # NOTE: rust-cross/manylinux docker images are CentOS based
@@ -70,6 +74,9 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}
           path: dist
 
+  #
+  # TODO: Figure out how to get this to work with external dependencies...
+  #
   # musllinux:
   #   runs-on: ${{ matrix.platform.runner }}
   #   strategy:
@@ -92,7 +99,7 @@ jobs:
   #       uses: PyO3/maturin-action@v1
   #       with:
   #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
+  #         args: --release --out dist --interpreter python3.10 python3.11 python3.12
   #         sccache: 'true'
   #         manylinux: musllinux_1_2
   #         before-script-linux: |
@@ -106,7 +113,8 @@ jobs:
   #               sudo apt-get install -y libasound2-dev
   #               ;;
   #             "x86" | "x86_64")
-  #               # NOTE: rust-cross/rust-musl-cross actually seem Ubuntu based.
+  #               # NOTE: rust-cross/rust-musl-cross actually seem Ubuntu based (in contrast to rust-cross/manylinux?)
+  #               # See: https://github.com/rust-cross/rust-musl-cross/blob/main/Dockerfile
   #               sudo apt-get update
   #               sudo apt-get install -y libasound2-dev
   #               ;;
@@ -136,7 +144,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
+          args: --release --out dist --interpreter python3.10 python3.11 python3.12
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -162,7 +170,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
+          args: --release --out dist --interpreter python3.10 python3.11 python3.12
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,9 @@ jobs:
           manylinux: auto
           before-script-linux: |
             echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
+            uname -a
+            lsb_release -a
+            cat /etc/*-release
             case "${{ matrix.platform.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based
@@ -59,7 +62,7 @@ jobs:
               "x86" | "x86_64")
                 # NOTE: rust-cross/manylinux docker images are CentOS based
                 yum update -y
-                yum install -y libasound2-dev
+                yum install -y alsa-lib-devel
                 ;;
             esac
       - name: Upload wheels
@@ -95,6 +98,9 @@ jobs:
           manylinux: musllinux_1_2
           before-script-linux: |
             echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
+            uname -a
+            lsb_release -a
+            cat /etc/*-release
             case "${{ matrix.platform.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based
@@ -104,7 +110,7 @@ jobs:
               "x86" | "x86_64")
                 # NOTE: rust-cross/manylinux docker images are CentOS based
                 yum update -y
-                yum install -y libasound2-dev
+                yum install -y alsa-lib-devel
                 ;;
             esac
       - name: Upload wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,14 +28,14 @@ jobs:
             target: x86_64
           - runner: ubuntu-latest
             target: x86
-          - runner: ubuntu-latest
-            target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
-          - runner: ubuntu-latest
-            target: s390x
-          - runner: ubuntu-latest
-            target: ppc64le
+          # - runner: ubuntu-latest
+          #   target: aarch64
+          # - runner: ubuntu-latest
+          #   target: armv7
+          # - runner: ubuntu-latest
+          #   target: s390x
+          # - runner: ubuntu-latest
+          #   target: ppc64le
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -70,52 +70,52 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}
           path: dist
 
-  musllinux:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-latest
-            target: x86_64
-          - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
-            target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
-          sccache: 'true'
-          manylinux: musllinux_1_2
-          before-script-linux: |
-            echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
-            uname -a
-            cat /etc/*-release
-            case "${{ matrix.platform.target }}" in
-              "aarch64" | "armv7" | "s390x" | "ppc64le")
-                # NOTE: pypa/manylinux docker images are Debian based
-                sudo apt-get update
-                sudo apt-get install -y libasound2-dev
-                ;;
-              "x86" | "x86_64")
-                # NOTE: rust-cross/rust-musl-cross actually seem Ubuntu based.
-                sudo apt-get update
-                sudo apt-get install -y libasound2-dev
-                ;;
-            esac
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
-          path: dist
+  # musllinux:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: ubuntu-latest
+  #           target: x86_64
+  #         - runner: ubuntu-latest
+  #           target: x86
+  #         - runner: ubuntu-latest
+  #           target: aarch64
+  #         - runner: ubuntu-latest
+  #           target: armv7
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: 3.x
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12
+  #         sccache: 'true'
+  #         manylinux: musllinux_1_2
+  #         before-script-linux: |
+  #           echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
+  #           uname -a
+  #           cat /etc/*-release
+  #           case "${{ matrix.platform.target }}" in
+  #             "aarch64" | "armv7" | "s390x" | "ppc64le")
+  #               # NOTE: pypa/manylinux docker images are Debian based
+  #               sudo apt-get update
+  #               sudo apt-get install -y libasound2-dev
+  #               ;;
+  #             "x86" | "x86_64")
+  #               # NOTE: rust-cross/rust-musl-cross actually seem Ubuntu based.
+  #               sudo apt-get update
+  #               sudo apt-get install -y libasound2-dev
+  #               ;;
+  #           esac
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-musllinux-${{ matrix.platform.target }}
+  #         path: dist
 
   windows:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,8 @@ jobs:
               "armv7")
                 # Probably requires something more like this:
                 # https://askubuntu.com/a/1323570/161463
+                sudo apt-get update
+                sudo apt-get install -y apt-transport-https
                 sudo dpkg --add-architecture armhf
                 sudo apt-get update
                 sudo apt-get install -y libasound2-dev:armhf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,9 +106,9 @@ jobs:
                 sudo apt-get install -y libasound2-dev
                 ;;
               "x86" | "x86_64")
-                # NOTE: rust-cross/manylinux docker images are CentOS based
-                yum update -y
-                yum install -y alsa-lib-devel
+                # NOTE: rust-cross/rust-musl-cross actually seem Ubuntu based.
+                sudo apt-get update
+                sudo apt-get install -y libasound2-dev
                 ;;
             esac
       - name: Upload wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
                 sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security multiverse" >> /etc/apt/sources.list
                 sudo apt-get update
                 sudo apt-get install -y libasound2-dev:armhf
+                export PKG_CONFIG_ALLOW_CROSS=1
                 ;;
               "x86" | "x86_64")
                 # NOTE: rust-cross/manylinux docker images are CentOS based

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,9 +61,18 @@ jobs:
               "armv7")
                 # Probably requires something more like this:
                 # https://askubuntu.com/a/1323570/161463
-                sudo apt-get update
-                sudo apt-get install -y apt-transport-https
                 sudo dpkg --add-architecture armhf
+                sudo sed -i "s/deb h/deb [arch=amd64] h/g" /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main restricted" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy universe" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates universe" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy multiverse" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates multiverse" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security universe" >> /etc/apt/sources.list
+                sudo echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security multiverse" >> /etc/apt/sources.list
                 sudo apt-get update
                 sudo apt-get install -y libasound2-dev:armhf
                 ;;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,6 @@ jobs:
           before-script-linux: |
             echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
             uname -a
-            lsb_release -a
             cat /etc/*-release
             case "${{ matrix.platform.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
@@ -99,7 +98,6 @@ jobs:
           before-script-linux: |
             echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
             uname -a
-            lsb_release -a
             cat /etc/*-release
             case "${{ matrix.platform.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
                 sudo apt-get install -y libasound2-dev
                 ;;
               "armv7")
+                # Probably requires something more like this:
+                # https://askubuntu.com/a/1323570/161463
+                sudo dpkg --add-architecture armhf
                 sudo apt-get update
                 sudo apt-get install -y libasound2-dev:armhf
                 ;;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,17 +49,17 @@ jobs:
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
-            echo "Running before-script-linux for target: ${{ matrix.target }}"
-            case "${{ matrix.target }}" in
+            echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
+            case "${{ matrix.platform.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based
                 sudo apt-get update
-                sudo apt-get install -y libasound2-dev libdbus-1-dev
+                sudo apt-get install -y libasound2-dev
                 ;;
               "x86" | "x86_64")
                 # NOTE: rust-cross/manylinux docker images are CentOS based
                 yum update -y
-                yum install -y libasound2-dev libdbus-1-dev
+                yum install -y libasound2-dev
                 ;;
             esac
       - name: Upload wheels
@@ -94,17 +94,17 @@ jobs:
           sccache: 'true'
           manylinux: musllinux_1_2
           before-script-linux: |
-            echo "Running before-script-linux for target: ${{ matrix.target }}"
-            case "${{ matrix.target }}" in
+            echo "Running before-script-linux for target: ${{ matrix.platform.target }}"
+            case "${{ matrix.platform.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based
                 sudo apt-get update
-                sudo apt-get install -y libasound2-dev libdbus-1-dev
+                sudo apt-get install -y libasound2-dev
                 ;;
               "x86" | "x86_64")
                 # NOTE: rust-cross/manylinux docker images are CentOS based
                 yum update -y
-                yum install -y libasound2-dev libdbus-1-dev
+                yum install -y libasound2-dev
                 ;;
             esac
       - name: Upload wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [linux, windows, macos, sdist] # musllinux
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
+            echo "Running before-script-linux for target: ${{ matrix.target }}"
             case "${{ matrix.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based
@@ -93,6 +94,7 @@ jobs:
           sccache: 'true'
           manylinux: musllinux_1_2
           before-script-linux: |
+            echo "Running before-script-linux for target: ${{ matrix.target }}"
             case "${{ matrix.target }}" in
               "aarch64" | "armv7" | "s390x" | "ppc64le")
                 # NOTE: pypa/manylinux docker images are Debian based

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,11 @@ jobs:
             target: x86_64
           - runner: ubuntu-latest
             target: x86
+          # TODO: Try to make cross compilation work again...
           # - runner: ubuntu-latest
           #   target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
+          # - runner: ubuntu-latest
+          #   target: armv7
           # - runner: ubuntu-latest
           #   target: s390x
           # - runner: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "appit"
-version = "0.4.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ed795976c3816aeceb52f1971d3e27f5403d58b16531edea7fe97f63e75f08"
+checksum = "7a158c9d2660ce603c741d513b44cdd97a4553e0749d4e49e45b9480fc72c162"
 dependencies = [
  "winit",
 ]
@@ -152,9 +152,9 @@ dependencies = [
 [[package]]
 name = "appit"
 version = "0.4.0"
-source = "git+https://github.com/khonsulabs/appit#be6918d5ebb6a2ad7911f621bb7db3676ce8b290"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ed795976c3816aeceb52f1971d3e27f5403d58b16531edea7fe97f63e75f08"
 dependencies = [
- "darkmode",
  "winit",
 ]
 
@@ -227,182 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading",
-]
-
-[[package]]
-name = "ashpd"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
-name = "async-broadcast"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
- "tracing",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
 ]
 
 [[package]]
@@ -534,34 +358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -931,15 +733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,16 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,7 +781,8 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "cushy"
 version = "0.4.0"
-source = "git+https://github.com/khonsulabs/cushy?rev=d032299fc584b64bbb07daef1d17f14ff154125b#d032299fc584b64bbb07daef1d17f14ff154125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95bab1d3662de0ac9f982b584cd7fd0f6c37bb17aca06a34b8ed5feb7248f16"
 dependencies = [
  "ahash",
  "alot",
@@ -1010,14 +794,13 @@ dependencies = [
  "intentional",
  "interner",
  "kempt",
- "kludgine 0.11.0 (git+https://github.com/khonsulabs/kludgine)",
+ "kludgine 0.10.0",
  "nominals",
  "palette",
  "parking_lot",
  "plotters",
  "png",
  "pollster",
- "rfd",
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
@@ -1027,7 +810,8 @@ dependencies = [
 [[package]]
 name = "cushy-macros"
 version = "0.4.0"
-source = "git+https://github.com/khonsulabs/cushy?rev=d032299fc584b64bbb07daef1d17f14ff154125b#d032299fc584b64bbb07daef1d17f14ff154125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0fe75f8899a9dc3d8d7541bebd0856c1d8c75db46b95f1465c45a246a84a9ed"
 dependencies = [
  "attribute-derive",
  "manyhow",
@@ -1049,30 +833,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "darkmode"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075a9464059e42ad7f7c487897c1ceb65327daf056c2acf58b27ca62a51db2ab"
-dependencies = [
- "dbus",
-]
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
-
-[[package]]
-name = "dbus"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
-dependencies = [
- "libc",
- "libdbus-sys",
- "winapi",
-]
 
 [[package]]
 name = "derive-where"
@@ -1083,16 +847,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -1186,33 +940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
-
-[[package]]
-name = "enumflags2"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,27 +981,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "exr"
 version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,12 +1001,6 @@ name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
-name = "fastrand"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fdeflate"
@@ -1440,15 +1140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "freetype-sys"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,90 +1148,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1728,12 +1335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,16 +1367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1971,37 +1562,13 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kludgine"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ee58ce44762ccebb879d0df90c736336f6230e633702c7a24643dff1fca25c"
+checksum = "0bc8757e03860f7a9a15e9616060ed620a12500a61c9ff9b457cccfc5f20af1f"
 dependencies = [
  "ahash",
  "alot",
- "appit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytemuck",
- "cosmic-text",
- "etagere",
- "figures",
- "image 0.25.4",
- "intentional",
- "justjson",
- "lyon_tessellation",
- "palette",
- "pollster",
- "raw-window-handle",
- "smallvec",
- "unicode-bidi",
- "wgpu",
-]
-
-[[package]]
-name = "kludgine"
-version = "0.11.0"
-source = "git+https://github.com/khonsulabs/kludgine#2f7755a1a9b7cae67711f7c41ee2cd2c6b12fd64"
-dependencies = [
- "ahash",
- "alot",
- "appit 0.4.0 (git+https://github.com/khonsulabs/appit)",
+ "appit 0.3.2",
  "bytemuck",
  "cosmic-text",
  "etagere",
@@ -2013,6 +1580,31 @@ dependencies = [
  "palette",
  "plotters",
  "plotters-backend",
+ "pollster",
+ "raw-window-handle",
+ "smallvec",
+ "unicode-bidi",
+ "wgpu",
+]
+
+[[package]]
+name = "kludgine"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ee58ce44762ccebb879d0df90c736336f6230e633702c7a24643dff1fca25c"
+dependencies = [
+ "ahash",
+ "alot",
+ "appit 0.4.0",
+ "bytemuck",
+ "cosmic-text",
+ "etagere",
+ "figures",
+ "image 0.25.4",
+ "intentional",
+ "justjson",
+ "lyon_tessellation",
+ "palette",
  "pollster",
  "raw-window-handle",
  "smallvec",
@@ -2048,15 +1640,6 @@ name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2367,19 +1950,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nom"
@@ -2751,16 +2321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,12 +2358,6 @@ dependencies = [
  "quote",
  "syn 2.0.85",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2906,7 +2460,7 @@ name = "picoapp"
 version = "0.1.1"
 dependencies = [
  "cushy",
- "kludgine 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kludgine 0.11.0",
  "log",
  "plotters",
  "pyo3",
@@ -2939,23 +2493,6 @@ name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3437,28 +2974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
-name = "rfd"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e"
-dependencies = [
- "ashpd",
- "block2",
- "js-sys",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "pollster",
- "raw-window-handle",
- "urlencoding",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,34 +3111,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -3640,15 +3133,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "simd-adler32"
@@ -3886,19 +3370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
-name = "tempfile"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
-dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,23 +3573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "uds_windows"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
-dependencies = [
- "memoffset",
- "tempfile",
- "winapi",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4147,15 +3601,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-properties"
@@ -4192,24 +3637,6 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "url"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "v_frame"
@@ -4972,16 +4399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,68 +4438,6 @@ dependencies = [
  "dlib",
  "once_cell",
  "pkg-config",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix",
- "ordered-stream",
- "rand",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.85",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant",
 ]
 
 [[package]]
@@ -5140,42 +4495,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
 dependencies = [
  "zune-core",
-]
-
-[[package]]
-name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "url",
- "zvariant_derive",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.85",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "picoapp"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "cushy",
  "kludgine 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picoapp"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 
-# cushy = { version = "0.4", features = ["plotters"] }
-cushy = { git = "https://github.com/khonsulabs/cushy", rev = "d032299fc584b64bbb07daef1d17f14ff154125b", features = ["plotters"] }
+cushy = { version = "0.4", features = ["plotters"] }
+# cushy = { git = "https://github.com/khonsulabs/cushy", rev = "d032299fc584b64bbb07daef1d17f14ff154125b", features = ["plotters"] }
 kludgine = "0.11"
 log = "0.4"
 plotters = { version = "0.3.6", features = ["fontconfig-dlopen"] }

--- a/examples/.backwards_compatible/example_0.1.0.py
+++ b/examples/.backwards_compatible/example_0.1.0.py
@@ -1,0 +1,27 @@
+# type: ignore
+
+import numpy as np
+
+import picoapp as pa
+
+inputs = [
+    (slider_a := pa.Slider("a", -10.0, 0.5, 10.0)),
+    (slider_b := pa.Slider("b", -10.0, 0.5, 10.0)),
+    (slider_c := pa.Slider("c", -10.0, 0.5, 10.0)),
+]
+
+
+def callback() -> pa.Outputs:
+    a = slider_a.value
+    b = slider_b.value
+    c = slider_c.value
+
+    xs = np.linspace(-10.0, 10.0, 100)
+    ys = a * xs**2 + b * xs + c
+
+    return pa.Outputs(
+        pa.Plot(xs, ys, x_limits=(-10, +10), y_limits=(-10, +10)),
+    )
+
+
+pa.run(inputs, callback)

--- a/notes.md
+++ b/notes.md
@@ -53,6 +53,14 @@ The maturin side can then take care of packaging up the linked `.so` into the ta
 https://github.com/rust-lang/pkg-config-rs/issues/109
 
 
+## ALSA specific findings
+
+- https://github.com/rust-cross/rust-musl-cross/issues/69
+  Basically describes exactly my problem
+- https://github.com/diwic/alsa-sys/issues/10
+  Is static linking an option?
+
+
 ## Maturin GitHub Actions
 
 Some notes / resources:

--- a/notes.md
+++ b/notes.md
@@ -4,7 +4,7 @@
 Useful command line snippets:
 
 ```sh
-maturin develop --uv && python example/example_1.py
+maturin develop --uv && python examples/example_1.py
 ```
 
 Note that I initially thought that I have to add `pip` to the `requirements.in`, because maturin errors when it doesn't find pip.
@@ -12,6 +12,30 @@ However, it looks like it actually can internally use `uv` as well:
 - https://github.com/PyO3/maturin/issues/1959
 - https://github.com/PyO3/maturin/pull/2015
 - https://github.com/PyO3/maturin/pull/2015/files
+
+
+# Deployment / Cross Compiling
+
+## Maturin GitHub Actions
+
+Some notes / resources:
+
+- https://github.com/PyO3/maturin-action/issues/276
+- https://github.com/PyO3/maturin-action/discussions/273#discussioncomment-9828658
+- https://github.com/astral-sh/uv/blob/ca92b55605fe37c354f42e1126185cae6e8d0d66/.github/workflows/build-binaries.yml#L227-L240
+
+
+## Snippets for testing deployed package on PyPI
+
+```sh
+TMP_VENV_DIR=/tmp/venv_dir
+rm -rf "$TMP_VENV_DIR"
+virtualenv "$TMP_VENV_DIR"
+. $TMP_VENV_DIR/bin/activate
+pip install picoapp numpy
+python -c "import picoapp; print(picoapp.__file__)"
+python example/example_1.py
+```
 
 
 # PyO3

--- a/notes.md
+++ b/notes.md
@@ -98,11 +98,38 @@ Some related questions that helped me to make it work:
 ### Using the installed libraries (different architecture) with package-config
 
 Still to be figured out...
+https://github.com/rust-lang/pkg-config-rs/issues/172
+
+Currently, I'm at the point that I successfully installed `libasound2-dev:armhf` and trying a desperate `PKG_CONFIG_ALLOW_CROSS=1`.
+But this errors with:
+
+```
+Could not run `PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags alsa`
+The pkg-config command could not be found.
+
+Most likely, you need to install a pkg-config package for your OS.
+Try `apt install pkg-config`, or `yum install pkg-config`,
+or `pkg install pkg-config`, or `apk add pkgconfig` depending on your distribution.
+
+If you've already installed it, ensure the pkg-config command is one of the
+directories in the PATH environment variable.
+
+If you did not expect this build to link to a pre-installed system library,
+then check documentation of the alsa-sys crate for an option to
+build the library from source, or disable features or dependencies
+that require pkg-config.
+```
+
+This kind of makes sense, because `libasound2-dev:armhf` probably didn't install itself in the default location?
 
 
+### What about cross-rs?
+
+I don't really understand if it would be usable with `maturin`:
+https://github.com/PyO3/maturin/discussions/2287
 
 
-## ALSA specific
+## ALSA related
 
 The library that we need is `libasound2.so`.
 
@@ -120,6 +147,13 @@ Some more findings:
   This example looks interesting because it directly shows how to cross compile against `libasound2-dev:armhf`.
   However this is for `cross-rs`, so I'm not sure if that helps for building with `maturin`?
 - https://stackoverflow.com/questions/57037550/alsa-linking-when-cross-compiling-rust-program-for-arm
+
+## dbus related
+
+- https://github.com/cross-rs/wiki_assets/tree/main/FAQ/dbus
+- https://github.com/diwic/dbus-rs/issues/399
+- https://github.com/diwic/dbus-rs/pull/408
+  Note that dbus-rs has a "vendored" build mode, which was also suggested for ALSA here: https://github.com/diwic/alsa-sys/issues/10#issuecomment-2182185812
 
 
 ## Maturin GitHub Actions

--- a/notes.md
+++ b/notes.md
@@ -147,8 +147,12 @@ Some more findings:
   This example looks interesting because it directly shows how to cross compile against `libasound2-dev:armhf`.
   However this is for `cross-rs`, so I'm not sure if that helps for building with `maturin`?
 - https://stackoverflow.com/questions/57037550/alsa-linking-when-cross-compiling-rust-program-for-arm
+  This looks interesting.
+
 
 ## dbus related
+
+Library name: `libdbus-1-dev`
 
 - https://github.com/cross-rs/wiki_assets/tree/main/FAQ/dbus
 - https://github.com/diwic/dbus-rs/issues/399
@@ -157,6 +161,9 @@ Some more findings:
 
 
 ## Maturin GitHub Actions
+
+For overview of the images used, see:
+https://github.com/PyO3/maturin-action?tab=readme-ov-file#manylinux-docker-container
 
 Some notes / resources:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "picoapp"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/src/widgets/ui_checkbox.rs
+++ b/src/widgets/ui_checkbox.rs
@@ -38,7 +38,7 @@ pub fn checkbox_widget(
 
     checkbox_state
         .clone()
-        .to_checkbox(&checkbox.name)
+        .to_checkbox(&*checkbox.name)
         .small()
         .contain()
 }

--- a/src/widgets/ui_radio.rs
+++ b/src/widgets/ui_radio.rs
@@ -39,7 +39,7 @@ pub fn radio_widget(
     options_widget_list.push(radio.name.clone().small());
 
     for (idx, name) in radio.value_names.iter().enumerate() {
-        options_widget_list.push(option.new_radio(idx, name).small());
+        options_widget_list.push(option.new_radio(idx, name.as_ref()).small());
     }
 
     options_widget_list.into_rows().contain()


### PR DESCRIPTION
- Disable failing architectures for now :disappointed: ([see diff](https://github.com/khonsulabs/cushy/commit/8bed71cfb5ab748e7017c7338c9ff6e67394a85f#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR35))
- Temporarily downpin cushy to postpone dealing with dbus issue.
- Limit Python versions to 3.10+.